### PR TITLE
Add GitHub update metadata to userscripts

### DIFF
--- a/tampermonkey/gallery-downloader-provider.user.js
+++ b/tampermonkey/gallery-downloader-provider.user.js
@@ -4,6 +4,10 @@
 // @version      0.5.0
 // @description  Offer a floating “Send to Downloader” button on supported gallery-dl provider domains.
 // @author       You
+// @homepageURL  https://github.com/blkot/GalleryDownloaderServer
+// @supportURL   https://github.com/blkot/GalleryDownloaderServer/issues
+// @updateURL    https://raw.githubusercontent.com/blkot/GalleryDownloaderServer/main/tampermonkey/gallery-downloader-provider.user.js
+// @downloadURL  https://raw.githubusercontent.com/blkot/GalleryDownloaderServer/main/tampermonkey/gallery-downloader-provider.user.js
 // @match        https://catbox.moe/*
 // @match        https://*.catbox.moe/*
 // @match        https://pixeldrain.com/*

--- a/tampermonkey/gallery-downloader-simpcity.user.js
+++ b/tampermonkey/gallery-downloader-simpcity.user.js
@@ -4,6 +4,10 @@
 // @version      0.6.0
 // @description  Decorate SimpCity threads with Gallery Downloader actions and normalised provider links.
 // @author       You
+// @homepageURL  https://github.com/blkot/GalleryDownloaderServer
+// @supportURL   https://github.com/blkot/GalleryDownloaderServer/issues
+// @updateURL    https://raw.githubusercontent.com/blkot/GalleryDownloaderServer/main/tampermonkey/gallery-downloader-simpcity.user.js
+// @downloadURL  https://raw.githubusercontent.com/blkot/GalleryDownloaderServer/main/tampermonkey/gallery-downloader-simpcity.user.js
 // @match        https://simpcity.cr/threads/*
 // @match        https://simpcity.su/threads/*
 // @match        https://simpcity.gs/threads/*


### PR DESCRIPTION
## Summary
- add `homepageURL` and `supportURL` metadata for both Tampermonkey scripts
- add `updateURL` and `downloadURL` metadata so installs can track the repo source
- keep the follow-up userscript metadata change separate from the already-merged host support PR
